### PR TITLE
Added parameterizeable RAM for butterfly units and tested it

### DIFF
--- a/src/main/scala/DSP228/RAM.scala
+++ b/src/main/scala/DSP228/RAM.scala
@@ -4,12 +4,16 @@ import chisel3.util._
 import chisel3.experimental.FixedPoint
 
 class RAMUnitIO(NumEntries: Int) extends Bundle {
-    val read = Input(Bool())
-    val in_valid = Input(Bool())
+    // read or write signal
+    val read = Flipped(Valid(Bool())) // if read.bits = high then read, else write
+    
+    // writing inputs
     val in_data1 = Input(FixedPoint(32.W, 8.BP))
     val in_data2 = Input(FixedPoint(32.W, 8.BP))
+    
     val addr1 = Input(UInt(log2Ceil(NumEntries).W))
     val addr2 = Input(UInt(log2Ceil(NumEntries).W))
+    
     val out_valid = Output(Bool())
     val out1 = Output(FixedPoint(32.W, 8.BP))
     val out2 = Output(FixedPoint(32.W, 8.BP))

--- a/src/main/scala/DSP228/RAM.scala
+++ b/src/main/scala/DSP228/RAM.scala
@@ -1,0 +1,20 @@
+package DSP228
+import chisel3._
+import chisel3.util._
+import chisel3.experimental.FixedPoint
+
+class RAM(N: Int) extends Module {
+    val io = IO(new Bundle {
+        val read = Input(Bool())
+        val in_valid = Input(Bool())
+        val addr1 = Input(UInt(log2Ceil(N).W))
+        val addr2 = Input(UInt(log2Ceil(N).W))
+        val out_valid = Output(Bool())
+        val out1 = Output(FixedPoint(32.W, 8.BP))
+        val out2 = Output(FixedPoint(32.W, 8.BP))
+    })
+    // TODO: Implement Behavior
+    io.out_valid := 0.B 
+    io.out1 := 0.F(32.W, 8.BP)
+    io.out2 := 0.F(32.W, 8.BP)
+}

--- a/src/main/scala/DSP228/RAM.scala
+++ b/src/main/scala/DSP228/RAM.scala
@@ -3,17 +3,24 @@ import chisel3._
 import chisel3.util._
 import chisel3.experimental.FixedPoint
 
-class RAM(N: Int) extends Module {
-    val io = IO(new Bundle {
-        val read = Input(Bool())
-        val in_valid = Input(Bool())
-        val addr1 = Input(UInt(log2Ceil(N).W))
-        val addr2 = Input(UInt(log2Ceil(N).W))
-        val out_valid = Output(Bool())
-        val out1 = Output(FixedPoint(32.W, 8.BP))
-        val out2 = Output(FixedPoint(32.W, 8.BP))
-    })
+class RAMUnitIO(NumEntries: Int) extends Bundle {
+    val read = Input(Bool())
+    val in_valid = Input(Bool())
+    val in_data1 = Input(FixedPoint(32.W, 8.BP))
+    val in_data2 = Input(FixedPoint(32.W, 8.BP))
+    val addr1 = Input(UInt(log2Ceil(NumEntries).W))
+    val addr2 = Input(UInt(log2Ceil(NumEntries).W))
+    val out_valid = Output(Bool())
+    val out1 = Output(FixedPoint(32.W, 8.BP))
+    val out2 = Output(FixedPoint(32.W, 8.BP))
+}
+
+class RAM(NumEntries: Int) extends Module {
+    val io = IO(new RAMUnitIO(NumEntries))
     // TODO: Implement Behavior
+    val mem1 = SyncReadMem(NumEntries, FixedPoint(32.W, 8.BP))
+    val mem2 = SyncReadMem(NumEntries, FixedPoint(32.W, 8.BP))
+
     io.out_valid := 0.B 
     io.out1 := 0.F(32.W, 8.BP)
     io.out2 := 0.F(32.W, 8.BP)

--- a/src/main/scala/DSP228/RAM.scala
+++ b/src/main/scala/DSP228/RAM.scala
@@ -5,16 +5,17 @@ import chisel3.experimental.FixedPoint
 
 class RAMUnitIO(NumEntries: Int) extends Bundle {
     // read or write signal
-    val read = Flipped(Valid(Bool())) // if read.bits = high then read, else write
+    val read = Input(Bool()) // if read = high then read, else write
     
     // writing inputs
     val in_data1 = Input(FixedPoint(32.W, 8.BP))
     val in_data2 = Input(FixedPoint(32.W, 8.BP))
     
+    // addresses
     val addr1 = Input(UInt(log2Ceil(NumEntries).W))
     val addr2 = Input(UInt(log2Ceil(NumEntries).W))
     
-    val out_valid = Output(Bool())
+    // output signals
     val out1 = Output(FixedPoint(32.W, 8.BP))
     val out2 = Output(FixedPoint(32.W, 8.BP))
 }
@@ -24,8 +25,17 @@ class RAM(NumEntries: Int) extends Module {
     // TODO: Implement Behavior
     val mem1 = SyncReadMem(NumEntries, FixedPoint(32.W, 8.BP))
     val mem2 = SyncReadMem(NumEntries, FixedPoint(32.W, 8.BP))
-
-    io.out_valid := 0.B 
-    io.out1 := 0.F(32.W, 8.BP)
-    io.out2 := 0.F(32.W, 8.BP)
+    
+    io.out1 := DontCare
+    io.out2 := DontCare
+    
+    val rdwr_port1 = mem1(io.addr1)
+    val rdwr_port2 = mem1(io.addr2)
+    when(io.read) {
+        io.out1 := rdwr_port1
+        io.out2 := rdwr_port2
+    } .otherwise {
+        rdwr_port1 := io.in_data1
+        rdwr_port2 := io.in_data2
+    }
 }

--- a/src/main/scala/DSP228/RAM.scala
+++ b/src/main/scala/DSP228/RAM.scala
@@ -4,6 +4,9 @@ import chisel3.util._
 import chisel3.experimental.FixedPoint
 
 class RAMUnitIO(NumEntries: Int) extends Bundle {
+    // enable signal
+    val enable = Input(Bool())
+
     // read or write signal
     val read = Input(Bool()) // if read = high then read, else write
     
@@ -22,20 +25,21 @@ class RAMUnitIO(NumEntries: Int) extends Bundle {
 
 class RAM(NumEntries: Int) extends Module {
     val io = IO(new RAMUnitIO(NumEntries))
-    // TODO: Implement Behavior
+    // TODO: Do we need a valid signal?
     val mem1 = SyncReadMem(NumEntries, FixedPoint(32.W, 8.BP))
     val mem2 = SyncReadMem(NumEntries, FixedPoint(32.W, 8.BP))
     
     io.out1 := DontCare
     io.out2 := DontCare
-    
-    val rdwr_port1 = mem1(io.addr1)
-    val rdwr_port2 = mem1(io.addr2)
-    when(io.read) {
-        io.out1 := rdwr_port1
-        io.out2 := rdwr_port2
-    } .otherwise {
-        rdwr_port1 := io.in_data1
-        rdwr_port2 := io.in_data2
+    when(io.enable) {
+        val rdwr_port1 = mem1(io.addr1)
+        val rdwr_port2 = mem1(io.addr2)
+        when(io.read) {
+            io.out1 := rdwr_port1
+            io.out2 := rdwr_port2
+        } .otherwise {
+            rdwr_port1 := io.in_data1
+            rdwr_port2 := io.in_data2
+        }
     }
 }

--- a/src/main/scala/DSP228/RAM.scala
+++ b/src/main/scala/DSP228/RAM.scala
@@ -25,7 +25,7 @@ class RAMUnitIO(NumEntries: Int) extends Bundle {
 
 class RAM(NumEntries: Int) extends Module {
     val io = IO(new RAMUnitIO(NumEntries))
-    // TODO: Do we need a valid signal?
+    // TODO: ???
     val mem1 = SyncReadMem(NumEntries, FixedPoint(32.W, 8.BP))
     val mem2 = SyncReadMem(NumEntries, FixedPoint(32.W, 8.BP))
     

--- a/src/test/scala/DSP228/RAMTester.scala
+++ b/src/test/scala/DSP228/RAMTester.scala
@@ -5,28 +5,36 @@ import chiseltest._
 import org.scalatest.flatspec.AnyFlatSpec
 
 class RAMTester extends AnyFlatSpec with ChiselScalatestTester {
+    def doWriteTest(dut: RAM, in1: Double, in2: Double, w_addr1: Int, w_addr2: Int) : Unit = {
+        dut.io.enable.poke(true.B)
+        dut.io.read.poke(false.B)
+        dut.io.in_data1.poke(in1.F(32.W, 8.BP))
+        dut.io.in_data2.poke(in2.F(32.W, 8.BP))
+        dut.io.addr1.poke(w_addr1.U)
+        dut.io.addr2.poke(w_addr2.U)
+        dut.clock.step()
+        // TODO: could add extra clock step for safety?
+    }
+
+    def doReadTest(dut: RAM, r_exp_out1: Double, r_exp_out2: Double, r_addr1: Int, r_addr2: Int) : Unit = {
+        dut.io.enable.poke(true.B)
+        dut.io.read.poke(true.B)
+        dut.io.addr1.poke(r_addr1.U)
+        dut.io.addr2.poke(r_addr2.U)
+        dut.clock.step()
+        dut.io.out1.expect(r_exp_out1.F(32.W, 8.BP))
+        dut.io.out2.expect(r_exp_out2.F(32.W, 8.BP))
+        dut.clock.step()
+    }
+    
     behavior of "RAM"
     it should "correctly writes two floats to RAM then reads them back" in {
         test(new RAM(8)) { dut =>
-            // enable
-            dut.io.enable.poke(true.B)
-            
             // write signal
-            dut.io.read.poke(false.B)
-            dut.io.in_data1.poke(5.F(32.W, 8.BP))
-            dut.io.in_data2.poke(7.F(32.W, 8.BP))
-            dut.io.addr1.poke(0.U)
-            dut.io.addr2.poke(1.U)
-            dut.clock.step(2)
+            doWriteTest(dut, 5.0, 7.0, 0, 1)
 
             // read signal
-            dut.io.read.poke(true.B)
-            dut.io.addr1.poke(0.U)
-            dut.io.addr2.poke(1.U)
-            dut.clock.step()
-            dut.io.out1.expect(5.F(32.W, 8.BP))
-            dut.io.out2.expect(7.F(32.W, 8.BP))
-            dut.clock.step()
+            doReadTest(dut, 5.0, 7.0, 0, 1)
         }
     }
 

--- a/src/test/scala/DSP228/RAMTester.scala
+++ b/src/test/scala/DSP228/RAMTester.scala
@@ -8,6 +8,9 @@ class RAMTester extends AnyFlatSpec with ChiselScalatestTester {
     behavior of "RAM"
     it should "correctly writes two floats to RAM then reads them back" in {
         test(new RAM(8)) { dut =>
+            // enable
+            dut.io.enable.poke(true.B)
+            
             // write signal
             dut.io.read.poke(false.B)
             dut.io.in_data1.poke(5.F(32.W, 8.BP))

--- a/src/test/scala/DSP228/RAMTester.scala
+++ b/src/test/scala/DSP228/RAMTester.scala
@@ -1,0 +1,24 @@
+package DSP228
+
+import chisel3._
+import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
+
+class RAMTester extends AnyFlatSpec with ChiselScalatestTester {
+    behavior of "RAM"
+    it should "correctly have output valid false" in {
+        test(new RAM(8)) { dut =>
+            dut.io.read.valid.poke(false.B)
+            dut.io.read.bits.poke(true.B)
+            dut.io.in_data1.poke(0.F(32.W, 8.BP))
+            dut.io.in_data2.poke(0.F(32.W, 8.BP))
+            dut.io.addr1.poke(0.U)
+            dut.io.addr2.poke(0.U)
+
+            dut.io.out_valid.expect(false.B)
+            dut.io.out1.expect(0.F(32.W, 8.BP))
+            dut.io.out2.expect(0.F(32.W, 8.BP))
+        }
+    }
+
+}

--- a/src/test/scala/DSP228/RAMTester.scala
+++ b/src/test/scala/DSP228/RAMTester.scala
@@ -38,4 +38,24 @@ class RAMTester extends AnyFlatSpec with ChiselScalatestTester {
         }
     }
 
+    it should "correctly write to all RAM and read it all back" in {
+        test(new RAM(16)) { dut =>
+            for(i <- 0 until 16) {
+                doWriteTest(dut, i.toDouble, i.toDouble, i, i)
+            }
+
+            for(j <- 0 until 16) {
+                doReadTest(dut, j.toDouble, j.toDouble, j, j)
+            }
+        }
+    }
+
+    it should "correctly write one and read one element to the entire RAM" in {
+        test(new RAM(32)) { dut =>
+            for (i <- 0 until 32) {
+                doWriteTest(dut, i.toDouble, i.toDouble, i, i)
+                doReadTest(dut, i.toDouble, i.toDouble, i, i)
+            }
+        }
+    }
 }

--- a/src/test/scala/DSP228/RAMTester.scala
+++ b/src/test/scala/DSP228/RAMTester.scala
@@ -6,18 +6,24 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 class RAMTester extends AnyFlatSpec with ChiselScalatestTester {
     behavior of "RAM"
-    it should "correctly have output valid false" in {
+    it should "correctly writes two floats to RAM then reads them back" in {
         test(new RAM(8)) { dut =>
-            dut.io.read.valid.poke(false.B)
-            dut.io.read.bits.poke(true.B)
-            dut.io.in_data1.poke(0.F(32.W, 8.BP))
-            dut.io.in_data2.poke(0.F(32.W, 8.BP))
+            // write signal
+            dut.io.read.poke(false.B)
+            dut.io.in_data1.poke(5.F(32.W, 8.BP))
+            dut.io.in_data2.poke(7.F(32.W, 8.BP))
             dut.io.addr1.poke(0.U)
-            dut.io.addr2.poke(0.U)
+            dut.io.addr2.poke(1.U)
+            dut.clock.step(2)
 
-            dut.io.out_valid.expect(false.B)
-            dut.io.out1.expect(0.F(32.W, 8.BP))
-            dut.io.out2.expect(0.F(32.W, 8.BP))
+            // read signal
+            dut.io.read.poke(true.B)
+            dut.io.addr1.poke(0.U)
+            dut.io.addr2.poke(1.U)
+            dut.clock.step()
+            dut.io.out1.expect(5.F(32.W, 8.BP))
+            dut.io.out2.expect(7.F(32.W, 8.BP))
+            dut.clock.step()
         }
     }
 


### PR DESCRIPTION
Added
- RAM.scala: RAM module which can be parameterized, internally has two SyncReadMem, one cycle read and write latency
- RAMTester.scala: RAM module tester, tests the working.