### PR TITLE
Added real and imaginary parts for the RAM

### DIFF
--- a/src/main/scala/DSP228/RAM.scala
+++ b/src/main/scala/DSP228/RAM.scala
@@ -11,35 +11,51 @@ class RAMUnitIO(NumEntries: Int) extends Bundle {
     val read = Input(Bool()) // if read = high then read, else write
     
     // writing inputs
-    val in_data1 = Input(FixedPoint(32.W, 8.BP))
-    val in_data2 = Input(FixedPoint(32.W, 8.BP))
+    val realIn1 = Input(FixedPoint(32.W, 8.BP))
+    val realIn2 = Input(FixedPoint(32.W, 8.BP))
+    val imagIn1 = Input(FixedPoint(32.W, 8.BP))
+    val imagIn2 = Input(FixedPoint(32.W, 8.BP))
     
     // addresses
     val addr1 = Input(UInt(log2Ceil(NumEntries).W))
     val addr2 = Input(UInt(log2Ceil(NumEntries).W))
     
     // output signals
-    val out1 = Output(FixedPoint(32.W, 8.BP))
-    val out2 = Output(FixedPoint(32.W, 8.BP))
+    val realOut1 = Output(FixedPoint(32.W, 8.BP))
+    val realOut2 = Output(FixedPoint(32.W, 8.BP))
+    val imagOut1 = Output(FixedPoint(32.W, 8.BP))
+    val imagOut2 = Output(FixedPoint(32.W, 8.BP))
 }
 
 class RAM(NumEntries: Int) extends Module {
     val io = IO(new RAMUnitIO(NumEntries))
     // TODO: ???
-    val mem1 = SyncReadMem(NumEntries, FixedPoint(32.W, 8.BP))
-    val mem2 = SyncReadMem(NumEntries, FixedPoint(32.W, 8.BP))
+    val realMem1 = SyncReadMem(NumEntries, FixedPoint(32.W, 8.BP))
+    val realMem2 = SyncReadMem(NumEntries, FixedPoint(32.W, 8.BP))
+    val imagMem1 = SyncReadMem(NumEntries, FixedPoint(32.W, 8.BP))
+    val imagMem2 = SyncReadMem(NumEntries, FixedPoint(32.W, 8.BP))
     
-    io.out1 := DontCare
-    io.out2 := DontCare
+    io.realOut1 := DontCare
+    io.realOut2 := DontCare
+    io.imagOut1 := DontCare
+    io.imagOut2 := DontCare
+    
     when(io.enable) {
-        val rdwr_port1 = mem1(io.addr1)
-        val rdwr_port2 = mem1(io.addr2)
+        val rdwr_real1 = realMem1(io.addr1)
+        val rdwr_real2 = realMem2(io.addr2)
+        val rdwr_imag1 = imagMem1(io.addr1)
+        val rdwr_imag2 = imagMem2(io.addr2)
+        
         when(io.read) {
-            io.out1 := rdwr_port1
-            io.out2 := rdwr_port2
+            io.realOut1 := rdwr_real1
+            io.realOut2 := rdwr_real2
+            io.imagOut1 := rdwr_imag1
+            io.imagOut2 := rdwr_imag2
         } .otherwise {
-            rdwr_port1 := io.in_data1
-            rdwr_port2 := io.in_data2
+            rdwr_real1 := io.realIn1
+            rdwr_real2 := io.realIn2
+            rdwr_imag1 := io.imagIn1
+            rdwr_imag2 := io.imagIn2
         }
     }
 }

--- a/src/test/scala/DSP228/RAMTester.scala
+++ b/src/test/scala/DSP228/RAMTester.scala
@@ -5,25 +5,29 @@ import chiseltest._
 import org.scalatest.flatspec.AnyFlatSpec
 
 class RAMTester extends AnyFlatSpec with ChiselScalatestTester {
-    def doWriteTest(dut: RAM, in1: Double, in2: Double, w_addr1: Int, w_addr2: Int) : Unit = {
+    def doWriteTest(dut: RAM, real1: Double, real2: Double, imag1: Double, imag2: Double, w_addr1: Int, w_addr2: Int) : Unit = {
         dut.io.enable.poke(true.B)
         dut.io.read.poke(false.B)
-        dut.io.in_data1.poke(in1.F(32.W, 8.BP))
-        dut.io.in_data2.poke(in2.F(32.W, 8.BP))
+        dut.io.realIn1.poke(real1.F(32.W, 8.BP))
+        dut.io.realIn2.poke(real2.F(32.W, 8.BP))
+        dut.io.imagIn1.poke(imag1.F(32.W, 8.BP))
+        dut.io.imagIn2.poke(imag2.F(32.W, 8.BP))
         dut.io.addr1.poke(w_addr1.U)
         dut.io.addr2.poke(w_addr2.U)
         dut.clock.step()
         // TODO: could add extra clock step for safety?
     }
 
-    def doReadTest(dut: RAM, r_exp_out1: Double, r_exp_out2: Double, r_addr1: Int, r_addr2: Int) : Unit = {
+    def doReadTest(dut: RAM, r_exp_out1: Double, r_exp_out2: Double, i_exp_out1: Double, i_exp_out2: Double, r_addr1: Int, r_addr2: Int) : Unit = {
         dut.io.enable.poke(true.B)
         dut.io.read.poke(true.B)
         dut.io.addr1.poke(r_addr1.U)
         dut.io.addr2.poke(r_addr2.U)
         dut.clock.step()
-        dut.io.out1.expect(r_exp_out1.F(32.W, 8.BP))
-        dut.io.out2.expect(r_exp_out2.F(32.W, 8.BP))
+        dut.io.realOut1.expect(r_exp_out1.F(32.W, 8.BP))
+        dut.io.realOut2.expect(r_exp_out2.F(32.W, 8.BP))
+        dut.io.imagOut1.expect(i_exp_out1.F(32.W, 8.BP))
+        dut.io.imagOut2.expect(i_exp_out2.F(32.W, 8.BP))
         dut.clock.step()
     }
     
@@ -31,21 +35,21 @@ class RAMTester extends AnyFlatSpec with ChiselScalatestTester {
     it should "correctly writes two floats to RAM then reads them back" in {
         test(new RAM(8)) { dut =>
             // write signal
-            doWriteTest(dut, 5.0, 7.0, 0, 1)
+            doWriteTest(dut, 5.0, 7.0, 5.0, 7.0, 0, 1)
 
             // read signal
-            doReadTest(dut, 5.0, 7.0, 0, 1)
+            doReadTest(dut, 5.0, 7.0, 5.0, 7.0, 0, 1)
         }
     }
 
     it should "correctly write to all RAM and read it all back" in {
         test(new RAM(16)) { dut =>
             for(i <- 0 until 16) {
-                doWriteTest(dut, i.toDouble, i.toDouble, i, i)
+                doWriteTest(dut, i.toDouble, i.toDouble, i.toDouble, i.toDouble, i, i)
             }
 
             for(j <- 0 until 16) {
-                doReadTest(dut, j.toDouble, j.toDouble, j, j)
+                doReadTest(dut, j.toDouble, j.toDouble, j.toDouble, j.toDouble, j, j)
             }
         }
     }
@@ -53,8 +57,8 @@ class RAMTester extends AnyFlatSpec with ChiselScalatestTester {
     it should "correctly write one and read one element to the entire RAM" in {
         test(new RAM(32)) { dut =>
             for (i <- 0 until 32) {
-                doWriteTest(dut, i.toDouble, i.toDouble, i, i)
-                doReadTest(dut, i.toDouble, i.toDouble, i, i)
+                doWriteTest(dut, i.toDouble, i.toDouble, i.toDouble, i.toDouble, i, i)
+                doReadTest(dut, i.toDouble, i.toDouble, i.toDouble, i.toDouble, i, i)
             }
         }
     }


### PR DESCRIPTION
Changes:
- RAM.scala: instead of two syncReadMems, added four (two real, two imaginary)
- RAMTester.scala: made necessary changes to the tester functions
Passes all tests